### PR TITLE
Fix source dir path for installing docs when not building in source root

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -262,7 +262,7 @@ install-libraries: libraries
 install-doc-html: make-docs-html
 	@$(INSTALL_DATA_DIR) "$(DESTDIR)$(pkglibdir)/html"
 	@echo "Installing HTML documentation in $(DESTDIR)$(pkglibdir)/html"
-	@list='doc/*.html'; for i in $$list; do \
+	@list='$(srcdir)/doc/*.html'; for i in $$list; do \
 	    if test -f $$i ; then \
 		echo "Installing $$i"; \
 		$(INSTALL_DATA) $$i "$(DESTDIR)$(pkglibdir)/html"; \
@@ -272,7 +272,7 @@ install-doc-html: make-docs-html
 install-doc-n: make-docs-n
 	@$(INSTALL_DATA_DIR) "$(DESTDIR)$(mandir)/mann"
 	@echo "Installing nroff documentation in $(DESTDIR)$(mandir)/mann"
-	@list='doc/*.n'; for i in $$list; do \
+	@list='$(srcdir)/doc/*.n'; for i in $$list; do \
 	    if test -f $$i ; then \
 		if test -f "$(DESTDIR)$(mandir)/mann/Tcl.n.gz" -o \
 		    "$(DESTDIR)$(mandir)/mann/Tcl*.n.gz" ; then \


### PR DESCRIPTION
Install target does not find documentation files as it assumes running in root of source tree.